### PR TITLE
Removed --alldrivers instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Your Mac must not have a Core 2 duo or Solo (or older) processor - only the past
 0. Back your shit up
 0. No really, make sure you have a working backup. This procedure has been tested multiple times, but it's still possible things will go wrong and lose data.
 1. Download rEFInd (http://www.rodsbooks.com/refind/getting.html) as a "Binary zip file" and decompress it. Open Terminal and cd into the decompressed folder.
-2. Install rEFInd to the ESP partition (`$ ./refind-install --alldrivers`)
+2. Install rEFInd to the ESP partition (`$ ./refind-install`)
 3. Mount your ESP partition (`$ mkdir /Volumes/ESP && sudo mount -t msdos /dev/disk0s1 /Volumes/ESP/`)
 4. Rename the refind directory (`$ mv /Volumes/ESP/EFI/refind /Volumes/ESP/EFI/BOOT`)
 5. Rename the refind EFI blob (`$ mv /Volumes/ESP/EFI/BOOT/refind_x64.efi /Volumes/ESP/EFI/BOOT/bootx64.efi`)


### PR DESCRIPTION
Understanding the comments in https://github.com/aroman/freya-on-a-mac/issues/33 the `--alldrivers` parameter shouldn´t be necessary anymore.
